### PR TITLE
Wrong result when multiple instances of video_to_slomo.py are executed in parallel

### DIFF
--- a/video_to_slomo.py
+++ b/video_to_slomo.py
@@ -106,7 +106,7 @@ def main():
 
     # Create extraction folder and extract frames
     IS_WINDOWS = 'Windows' == platform.system()
-    extractionDir = "tmpSuperSloMo"
+    extractionDir = f"tmpSuperSloMo-{os.getpid()}"
     if not IS_WINDOWS:
         # Assuming UNIX-like system where "." indicates hidden directories
         extractionDir = "." + extractionDir


### PR DESCRIPTION
Since video_to_slomo.py uses fixed working directory "tmpSuperSloMo", multiple instances of video_to_slomo.py may result is wrong result.
